### PR TITLE
Use databuilder instead of cohortextractor-v2 image

### DIFF
--- a/analysis/study_definition.py
+++ b/analysis/study_definition.py
@@ -1,4 +1,4 @@
-from cohortextractor import codelist, table
+from databuilder import codelist, table
 
 
 class Cohort:

--- a/project.yaml
+++ b/project.yaml
@@ -6,7 +6,7 @@ expectations:
 actions:
 
   generate_study_population:
-    run: cohortextractor-v2:latest generate_cohort --cohort-definition analysis/study_definition.py --output output/input.csv
+    run: databuilder:latest generate_cohort --cohort-definition analysis/study_definition.py --output output/input.csv
     outputs:
       highly_sensitive:
         cohort: output/input.csv

--- a/project.yaml
+++ b/project.yaml
@@ -6,7 +6,7 @@ expectations:
 actions:
 
   generate_study_population:
-    run: databuilder:latest generate_cohort --cohort-definition analysis/study_definition.py --output output/input.csv
+    run: databuilder:v0 generate_cohort --cohort-definition analysis/study_definition.py --output output/input.csv
     outputs:
       highly_sensitive:
         cohort: output/input.csv


### PR DESCRIPTION
This PR will move this repository to use the databuilder Docker image, instead of cohortextractor-v2.

It also moves away from using the `cohortextractor` shim.